### PR TITLE
correct dependencies of utils

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,11 +38,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@solid-aria/types": "workspace:^"
+    "@solid-aria/types": "workspace:^",
+    "@solid-primitives/utils": "^2.0.1"
   },
   "peerDependencies": {
-    "@solid-primitives/utils": "^2.0.1",
-    "clsx": "^1.1.1",
     "solid-js": "^1.4.0"
   },
   "publishConfig": {


### PR DESCRIPTION
clsx isn't used here anymore I think
also only solid-js should be a peer dependency, anything else that you're using is a normal dependency