### PR TITLE
Refactor createSlotId

### DIFF
--- a/packages/dialog/src/createDialog.ts
+++ b/packages/dialog/src/createDialog.ts
@@ -48,12 +48,13 @@ export function createDialog<T extends HTMLElement>(
   props: AriaDialogProps,
   ref: Accessor<T | undefined>
 ): DialogAria {
-  const defaultTitleId = createSlotId();
+  const [defaultTitleId] = createSlotId();
 
   const titleId = () => {
     return props["aria-label"] ? undefined : defaultTitleId();
   };
 
+  // eslint-disable-next-line solid/reactivity
   const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
 
   // Note: aria-modal has a bug in Safari which forces the first focusable element to be focused

--- a/packages/label/src/createField.ts
+++ b/packages/label/src/createField.ts
@@ -18,7 +18,7 @@
 import { HelpTextProps, Validation } from "@solid-aria/types";
 import { createSlotId, ID_PREFIX } from "@solid-aria/utils";
 import { combineProps } from "@solid-primitives/props";
-import { createMemo, JSX } from "solid-js";
+import { JSX } from "solid-js";
 
 import { AriaLabelProps, createLabel, LabelAria } from "./createLabel";
 
@@ -47,12 +47,8 @@ export interface FieldAria extends LabelAria {
 export function createField(props: AriaFieldProps): FieldAria {
   const { labelProps, fieldProps } = createLabel(props);
 
-  const description = createMemo(() => props.description);
-  const errorMessage = createMemo(() => props.errorMessage);
-  const validationState = createMemo(() => props.validationState);
-
-  const descriptionId = createSlotId(ID_PREFIX, [description, errorMessage, validationState]);
-  const errorMessageId = createSlotId(ID_PREFIX, [description, errorMessage, validationState]);
+  const [descriptionId, trackDescIdUse] = createSlotId(ID_PREFIX);
+  const [errorMessageId, trackErrorIdUse] = createSlotId(ID_PREFIX);
 
   const baseFieldProps: JSX.HTMLAttributes<any> = {
     get "aria-describedby"() {
@@ -72,12 +68,14 @@ export function createField(props: AriaFieldProps): FieldAria {
 
   const descriptionProps: JSX.HTMLAttributes<any> = {
     get id() {
+      trackDescIdUse();
       return descriptionId();
     }
   };
 
   const errorMessageProps: JSX.HTMLAttributes<any> = {
     get id() {
+      trackErrorIdUse();
       return errorMessageId();
     }
   };

--- a/packages/listbox/src/createListBoxOption.ts
+++ b/packages/listbox/src/createListBoxOption.ts
@@ -88,8 +88,8 @@ export function createListBoxOption<T extends HTMLElement>(
 ): ListBoxOptionAria {
   const context = useListBoxContext();
 
-  const labelId = createSlotId();
-  const descriptionId = createSlotId();
+  const [labelId, trackLabelIdUse] = createSlotId();
+  const [descriptionId, trackDescIdUse] = createSlotId();
 
   const manager = () => context.state().selectionManager();
 
@@ -167,12 +167,14 @@ export function createListBoxOption<T extends HTMLElement>(
 
   const labelProps = {
     get id() {
+      trackLabelIdUse();
       return labelId();
     }
   };
 
   const descriptionProps = {
     get id() {
+      trackDescIdUse();
       return descriptionId();
     }
   };

--- a/packages/menu/src/createMenuItem.ts
+++ b/packages/menu/src/createMenuItem.ts
@@ -106,9 +106,9 @@ export function createMenuItem<T extends HTMLElement>(
 ): MenuItemAria {
   const context = useMenuContext();
 
-  const labelId = createSlotId();
-  const descriptionId = createSlotId();
-  const keyboardId = createSlotId();
+  const [labelId] = createSlotId();
+  const [descriptionId] = createSlotId();
+  const [keyboardId] = createSlotId();
 
   const manager = () => context.state().selectionManager();
 


### PR DESCRIPTION
I've refactored the `createSlotId` helper to work in a way I've described on discord.

Instead of tracking a fixed array of dependencies to preform `document.getElementById` check — It'll track the actual id usage via separate `track()` function.

This way displaying the element with e.g. `descriptionId` can to toggled depending on a signal separate from signals that would be tracked with the deps array from before, and update the value of `descriptionId` accordingly.

I've run the tests this time! :)