### PR TITLE
Feat: refactor filterDOMProps util

### DIFF
--- a/.changeset/old-snakes-judge.md
+++ b/.changeset/old-snakes-judge.md
@@ -1,0 +1,33 @@
+---
+"@solid-aria/accordion": patch
+"@solid-aria/breadcrumbs": patch
+"@solid-aria/button": patch
+"@solid-aria/checkbox": patch
+"@solid-aria/collection": patch
+"@solid-aria/dialog": patch
+"@solid-aria/focus": patch
+"@solid-aria/i18n": patch
+"@solid-aria/interactions": patch
+"@solid-aria/label": patch
+"@solid-aria/link": patch
+"@solid-aria/list": patch
+"@solid-aria/listbox": patch
+"@solid-aria/menu": patch
+"@solid-aria/meter": patch
+"@solid-aria/overlays": patch
+"@solid-aria/primitives": patch
+"@solid-aria/progress": patch
+"@solid-aria/radio": patch
+"@solid-aria/select": patch
+"@solid-aria/selection": patch
+"@solid-aria/separator": patch
+"@solid-aria/switch": patch
+"@solid-aria/textfield": patch
+"@solid-aria/toggle": patch
+"@solid-aria/tree": patch
+"@solid-aria/types": patch
+"@solid-aria/utils": patch
+"@solid-aria/visually-hidden": patch
+---
+
+Refactor `filterDOMProps` to use `filterProps` from @solid-primitives/props.

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -95,7 +95,7 @@ function Accordion(props: AriaAccordionProps) {
 
   const { AccordionProvider, accordionProps, state } = createAccordion(props, () => ref);
 
-  const domProps = createMemo(() => filterDOMProps(props));
+  const domProps = filterDOMProps(props);
 
   const rootProps = mergeProps(domProps, accordionProps);
 

--- a/packages/accordion/test/createAccordion.test.tsx
+++ b/packages/accordion/test/createAccordion.test.tsx
@@ -51,10 +51,7 @@ function Accordion(props: AriaAccordionProps) {
 
   const { AccordionProvider, accordionProps, state } = createAccordion(props, () => ref);
 
-  const rootProps = mergeProps(
-    createMemo(() => filterDOMProps(props)),
-    accordionProps
-  );
+  const rootProps = mergeProps(filterDOMProps(props), accordionProps);
 
   return (
     <div {...rootProps} ref={ref}>

--- a/packages/breadcrumbs/src/createBreadcrumbs.ts
+++ b/packages/breadcrumbs/src/createBreadcrumbs.ts
@@ -50,7 +50,7 @@ export function createBreadcrumbs(props: AriaBreadcrumbsProps): BreadcrumbsAria 
 
   const formatMessage = createMessageFormatter(intlMessages);
 
-  const domProps = createMemo(() => filterDOMProps(others, { labelable: true }));
+  const domProps = filterDOMProps(others, { labelable: true });
 
   const navProps = mergeProps(domProps, {
     get "aria-label"() {

--- a/packages/button/src/createButton.ts
+++ b/packages/button/src/createButton.ts
@@ -141,7 +141,7 @@ export function createButton(
 
   const { focusableProps } = createFocusable(props, ref);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const baseButtonProps: JSX.HTMLAttributes<any> = {
     get "aria-haspopup"() {

--- a/packages/checkbox/src/createCheckboxGroup.ts
+++ b/packages/checkbox/src/createCheckboxGroup.ts
@@ -97,7 +97,7 @@ export function createCheckboxGroup(props: AriaCheckboxGroupProps): CheckboxGrou
 
   const { labelProps, fieldProps } = createLabel(createLabelProps);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const baseGroupProps = mergeProps(
     {

--- a/packages/dialog/src/createDialog.ts
+++ b/packages/dialog/src/createDialog.ts
@@ -54,8 +54,7 @@ export function createDialog<T extends HTMLElement>(
     return props["aria-label"] ? undefined : defaultTitleId();
   };
 
-  // eslint-disable-next-line solid/reactivity
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   // Note: aria-modal has a bug in Safari which forces the first focusable element to be focused
   // on mount when inside an iframe, no matter which element we programmatically focus.

--- a/packages/link/src/createLink.ts
+++ b/packages/link/src/createLink.ts
@@ -78,7 +78,7 @@ export function createLink<T extends HTMLElement = HTMLAnchorElement>(
 
   const { pressProps, isPressed } = createPress(createPressProps);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(others, { labelable: true })));
+  const domProps = filterDOMProps(others, { labelable: true });
 
   const isAnchorTag = () => local.elementType === "a";
 

--- a/packages/listbox/src/createListBox.ts
+++ b/packages/listbox/src/createListBox.ts
@@ -122,8 +122,7 @@ export function createListBox<T extends HTMLElement>(
 ): ListBoxAria {
   const defaultListboxId = createId();
 
-  // eslint-disable-next-line solid/reactivity
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const createSelectableListProps = mergeProps(props, {
     selectionManager: state.selectionManager,

--- a/packages/menu/src/createMenu.ts
+++ b/packages/menu/src/createMenu.ts
@@ -117,7 +117,7 @@ export function createMenu<T extends HTMLElement>(
 
   const state = createTreeState(props);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const createSelectableListProps = mergeProps(props, {
     selectionManager: state.selectionManager,

--- a/packages/progress/src/createProgressBar.ts
+++ b/packages/progress/src/createProgressBar.ts
@@ -104,7 +104,7 @@ export function createProgressBar(props: AriaProgressBarProps = {}): ProgressBar
   // eslint-disable-next-line solid/reactivity
   props = mergeProps(defaultProps, props);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const createLabelProps = mergeProps(props, {
     // select is not an HTML input element so it

--- a/packages/radio/src/createRadio.ts
+++ b/packages/radio/src/createRadio.ts
@@ -109,7 +109,7 @@ export function createRadio(
 
   const { focusableProps } = createFocusable(createFocusableProps, inputRef);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const inputProps = combineProps(domProps, pressProps, focusableProps, {
     type: "radio",

--- a/packages/radio/src/createRadioGroup.ts
+++ b/packages/radio/src/createRadioGroup.ts
@@ -122,7 +122,7 @@ export function createRadioGroup(props: AriaRadioGroupProps): RadioGroupAria {
 
   const { labelProps, fieldProps } = createLabel(createLabelProps);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   // When the radio group loses focus, reset the focusable radio to null if
   // there is no selection. This allows tabbing into the group from either

--- a/packages/select/src/createSelect.ts
+++ b/packages/select/src/createSelect.ts
@@ -198,7 +198,7 @@ export function createSelect<T extends HTMLElement>(
   const { labelProps, fieldProps, descriptionProps, errorMessageProps } =
     createField(createFieldProps);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const triggerProps = combineProps(typeSelectProps, menuTriggerProps, fieldProps);
 

--- a/packages/separator/src/createSeparator.ts
+++ b/packages/separator/src/createSeparator.ts
@@ -45,7 +45,7 @@ export interface SeparatorAria {
  * e.g. groups of menu items or sections of a page.
  */
 export function createSeparator(props: AriaSeparatorProps = {}): SeparatorAria {
-  const domProps = createMemo(() => filterDOMProps(props, { labelable: true }));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   // eslint-disable-next-line solid/reactivity
   const separatorProps = mergeProps(domProps, {

--- a/packages/textfield/src/createTextField.ts
+++ b/packages/textfield/src/createTextField.ts
@@ -144,7 +144,7 @@ export function createTextField<T extends TextFieldIntrinsicElements = DefaultEl
   const { focusableProps } = createFocusable(props, ref);
   const { labelProps, fieldProps, descriptionProps, errorMessageProps } = createField(props);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const baseInputProps: JSX.HTMLAttributes<any> = mergeProps(
     {

--- a/packages/toggle/src/createToggle.ts
+++ b/packages/toggle/src/createToggle.ts
@@ -119,7 +119,7 @@ export function createToggle(
 
   const { focusableProps } = createFocusable(props, inputRef);
 
-  const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
+  const domProps = filterDOMProps(props, { labelable: true });
 
   const baseToggleProps: JSX.InputHTMLAttributes<any> = {
     type: "checkbox",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,9 @@
   },
   "license": "MIT",
   "author": "Fabien Marie-Louise <fabienml.dev@gmail.com>",
-  "contributors": [],
+  "contributors": [
+    "Damian Tarnawski <gthetarnav@gmail.com>"
+  ],
   "sideEffects": false,
   "type": "module",
   "exports": {
@@ -48,6 +50,7 @@
   },
   "dependencies": {
     "@solid-aria/types": "^0.1.4",
+    "@solid-primitives/props": "^2.2.0",
     "@solid-primitives/utils": "^2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,10 +668,12 @@ importers:
   packages/utils:
     specifiers:
       '@solid-aria/types': ^0.1.4
+      '@solid-primitives/props': ^2.2.0
       '@solid-primitives/utils': ^2.1.0
       solid-js: ^1.4.4
     dependencies:
       '@solid-aria/types': link:../types
+      '@solid-primitives/props': 2.2.0_solid-js@1.4.6
       '@solid-primitives/utils': 2.1.1_solid-js@1.4.6
     devDependencies:
       solid-js: 1.4.6
@@ -2796,6 +2798,15 @@ packages:
       solid-js: 1.4.6
     dev: false
 
+  /@solid-primitives/props/2.2.0_solid-js@1.4.6:
+    resolution: {integrity: sha512-Yg3hQ6kz3gVh5v1Tj6RXNdFrmyMBT93vhusy3wPBM0gb2+HqjVKZ68u9WHQuW7scL/L2+cX8hDxGN/gAhrCFrg==}
+    peerDependencies:
+      solid-js: ^1.3.0
+    dependencies:
+      '@solid-primitives/utils': 2.2.1_solid-js@1.4.6
+      solid-js: 1.4.6
+    dev: false
+
   /@solid-primitives/utils/1.5.2_solid-js@1.4.4:
     resolution: {integrity: sha512-dZUHjzasuqS2lDO+PQCY1+jFmtWHlaP3tUvkX1Jr06LI/Ipa2P/ZNVSvuIoqQ0Bg+Ny27LvtrXxflZNeGtptvA==}
     peerDependencies:
@@ -2834,6 +2845,14 @@ packages:
       solid-js: ^1.4.1
     dependencies:
       solid-js: 1.4.7
+    dev: false
+
+  /@solid-primitives/utils/2.2.1_solid-js@1.4.6:
+    resolution: {integrity: sha512-vaBO3MGOpjzitbSAVuJkYZnzNPRl6sRrw2do390DEBbfeqMfPpW4fAEb5/tI4b5T13V1xAY+giHoxqvVg2SRhQ==}
+    peerDependencies:
+      solid-js: ^1.4.1
+    dependencies:
+      solid-js: 1.4.6
     dev: false
 
   /@testing-library/dom/7.31.2:


### PR DESCRIPTION
Refactors the filterDOMProps to do less work, and be easier to use
```ts
const domProps = mergeProps(createMemo(() => filterDOMProps(props, { labelable: true })));
const domProps = filterDOMProps(props, { labelable: true });
```
Besides the select package, all tests pass