### PR TITLE
Fix passing user props through

### DIFF
--- a/.changeset/rude-melons-own.md
+++ b/.changeset/rude-melons-own.md
@@ -1,6 +1,7 @@
 ---
 "@solid-aria/button": patch
 "@solid-aria/focus": patch
+"@solid-aria/textfield": patch
 ---
 
 Fix user props not being passed down to the returned props object. (#69)

--- a/.changeset/rude-melons-own.md
+++ b/.changeset/rude-melons-own.md
@@ -1,0 +1,6 @@
+---
+"@solid-aria/button": patch
+"@solid-aria/focus": patch
+---
+
+Fix user props not being passed down to the returned props object. (#69)

--- a/packages/button/src/createButton.ts
+++ b/packages/button/src/createButton.ts
@@ -14,13 +14,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable solid/reactivity */
 
 import { createFocusable } from "@solid-aria/focus";
 import { createPress } from "@solid-aria/interactions";
 import { ElementType } from "@solid-aria/types";
-import { filterDOMProps } from "@solid-aria/utils";
 import { combineProps } from "@solid-primitives/props";
-import { Accessor, createMemo, JSX, mergeProps, splitProps } from "solid-js";
+import { Accessor, JSX, mergeProps, splitProps } from "solid-js";
 
 import { AriaButtonProps } from "./types";
 
@@ -82,7 +82,6 @@ export function createButton(
     type: "button"
   };
 
-  // eslint-disable-next-line solid/reactivity
   props = mergeProps(defaultProps, props);
 
   const additionalButtonElementProps: JSX.ButtonHTMLAttributes<any> = {
@@ -120,12 +119,8 @@ export function createButton(
       }
     };
 
-  const additionalProps = mergeProps(
-    createMemo(() => {
-      return props.elementType === "button"
-        ? additionalButtonElementProps
-        : additionalOtherElementProps;
-    })
+  const additionalProps = mergeProps(() =>
+    props.elementType === "button" ? additionalButtonElementProps : additionalOtherElementProps
   );
 
   const [createPressProps] = splitProps(props, [
@@ -140,8 +135,6 @@ export function createButton(
   const { pressProps, isPressed } = createPress(createPressProps);
 
   const { focusableProps } = createFocusable(props, ref);
-
-  const domProps = filterDOMProps(props, { labelable: true });
 
   const baseButtonProps: JSX.HTMLAttributes<any> = {
     get "aria-haspopup"() {
@@ -169,13 +162,7 @@ export function createButton(
     }
   };
 
-  const buttonProps = combineProps(
-    additionalProps,
-    focusableProps,
-    pressProps,
-    domProps,
-    baseButtonProps
-  );
+  const buttonProps = combineProps(additionalProps, focusableProps, pressProps, baseButtonProps);
 
   return { buttonProps, isPressed };
 }

--- a/packages/button/test/createButton.test.tsx
+++ b/packages/button/test/createButton.test.tsx
@@ -15,6 +15,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { JSX } from "solid-js";
+
 import { createButton } from "../src";
 import { AriaButtonProps } from "../src/types";
 
@@ -87,5 +89,29 @@ describe("createButton", () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(buttonProps.rel).toBeUndefined();
+  });
+
+  it("user props are passed down to the returned button props", () => {
+    const ref = document.createElement("button");
+    const onMouseMove = jest.fn();
+    const props: AriaButtonProps<"button"> & JSX.IntrinsicElements["button"] = {
+      children: "Hello",
+      class: "test-class",
+      onMouseMove,
+      style: { color: "red" }
+    };
+
+    const { buttonProps } = createButton(props, () => ref);
+
+    expect(buttonProps.children).toBe("Hello");
+    expect(buttonProps.class).toBe("test-class");
+    expect(buttonProps.style).toEqual({ color: "red" });
+
+    expect(buttonProps).toHaveProperty("onMouseMove");
+    expect(typeof buttonProps.onMouseMove).toBe("function");
+
+    // @ts-expect-error
+    buttonProps.onMouseMove();
+    expect(onMouseMove).toHaveBeenCalled();
   });
 });

--- a/packages/focus/src/createFocusable.ts
+++ b/packages/focus/src/createFocusable.ts
@@ -45,11 +45,11 @@ export interface CreateFocusableProps extends CreateFocusProps, CreateKeyboardPr
   excludeFromTabOrder?: MaybeAccessor<boolean | undefined>;
 }
 
-export interface FocusableResult<Props = {}> {
+export interface FocusableResult {
   /**
    * Props to spread onto the target element.
    */
-  focusableProps: Props & JSX.HTMLAttributes<any>;
+  focusableProps: JSX.HTMLAttributes<any>;
 }
 
 // TODO: add all the focus provider stuff when needed
@@ -57,10 +57,10 @@ export interface FocusableResult<Props = {}> {
 /**
  * Make an element focusable, capable of auto focus and excludable from tab order.
  */
-export function createFocusable<Props extends CreateFocusableProps>(
-  props: Props,
+export function createFocusable(
+  props: CreateFocusableProps,
   ref: Accessor<HTMLElement | undefined>
-): FocusableResult<Props> {
+): FocusableResult {
   const [autofocus, setAutofocus] = createSignal(!!access(props.autofocus));
 
   const { focusProps } = createFocus(props);
@@ -70,7 +70,7 @@ export function createFocusable<Props extends CreateFocusableProps>(
     get tabIndex() {
       return access(props.excludeFromTabOrder) && !access(props.isDisabled) ? -1 : undefined;
     }
-  }) as Props;
+  });
 
   onMount(() => {
     autofocus() && ref()?.focus();

--- a/packages/focus/src/createFocusable.ts
+++ b/packages/focus/src/createFocusable.ts
@@ -45,11 +45,11 @@ export interface CreateFocusableProps extends CreateFocusProps, CreateKeyboardPr
   excludeFromTabOrder?: MaybeAccessor<boolean | undefined>;
 }
 
-export interface FocusableResult {
+export interface FocusableResult<Props = {}> {
   /**
    * Props to spread onto the target element.
    */
-  focusableProps: JSX.HTMLAttributes<any>;
+  focusableProps: Props & JSX.HTMLAttributes<any>;
 }
 
 // TODO: add all the focus provider stuff when needed
@@ -57,21 +57,20 @@ export interface FocusableResult {
 /**
  * Make an element focusable, capable of auto focus and excludable from tab order.
  */
-export function createFocusable(
-  props: CreateFocusableProps,
+export function createFocusable<Props extends CreateFocusableProps>(
+  props: Props,
   ref: Accessor<HTMLElement | undefined>
-): FocusableResult {
+): FocusableResult<Props> {
   const [autofocus, setAutofocus] = createSignal(!!access(props.autofocus));
 
   const { focusProps } = createFocus(props);
   const { keyboardProps } = createKeyboard(props);
 
-  const focusableProps = {
-    ...combineProps(focusProps, keyboardProps),
+  const focusableProps = combineProps(props, focusProps, keyboardProps, {
     get tabIndex() {
       return access(props.excludeFromTabOrder) && !access(props.isDisabled) ? -1 : undefined;
     }
-  };
+  }) as Props;
 
   onMount(() => {
     autofocus() && ref()?.focus();

--- a/packages/focus/test/createFocusable.test.ts
+++ b/packages/focus/test/createFocusable.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable solid/reactivity */
+import { JSX } from "solid-js";
+
+import { createFocusable, CreateFocusableProps } from "../src";
+
+describe("createFocusable", () => {
+  test("user props are passed through", () => {
+    const ref = document.createElement("button");
+    const onClick = jest.fn();
+    const props: CreateFocusableProps & JSX.IntrinsicElements["button"] = {
+      children: "Hello",
+      class: "test-class",
+      onClick,
+      style: { color: "red" }
+    };
+
+    const { focusableProps } = createFocusable(props, () => ref);
+
+    expect(focusableProps.children).toBe("Hello");
+    expect(focusableProps.class).toBe("test-class");
+    expect(focusableProps.style).toEqual({ color: "red" });
+
+    expect(focusableProps).toHaveProperty("onClick");
+    expect(typeof focusableProps.onClick).toBe("function");
+
+    // @ts-expect-error
+    focusableProps.onClick();
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/packages/textfield/test/createTextField.test.ts
+++ b/packages/textfield/test/createTextField.test.ts
@@ -16,9 +16,9 @@
  */
 
 import { callHandler } from "@solid-aria/utils";
-import { createRoot } from "solid-js";
+import { createRoot, JSX } from "solid-js";
 
-import { createTextField } from "../src";
+import { AriaTextFieldProps, createTextField } from "../src";
 
 describe("createTextField", () => {
   it("should use default props if no props are provided", () =>
@@ -141,6 +141,33 @@ describe("createTextField", () => {
       // TS hack: cast to 'any' for checking if those props are undefined
       expect((inputProps as any).type).toBeUndefined();
       expect((inputProps as any).pattern).toBeUndefined();
+
+      dispose();
+    }));
+
+  it("user props are passed through", () =>
+    createRoot(dispose => {
+      const ref = document.createElement("input");
+      const onMouseMove = jest.fn();
+      const props: AriaTextFieldProps<"input"> & JSX.IntrinsicElements["input"] = {
+        children: "Hello",
+        class: "test-class",
+        onMouseMove,
+        style: { color: "red" }
+      };
+
+      const { inputProps } = createTextField(props, () => ref);
+
+      expect(inputProps.children).toBe("Hello");
+      expect(inputProps.class).toBe("test-class");
+      expect(inputProps.style).toEqual({ color: "red" });
+
+      expect(inputProps).toHaveProperty("onMouseMove");
+      expect(typeof inputProps.onMouseMove).toBe("function");
+
+      // @ts-expect-error
+      inputProps.onMouseMove();
+      expect(onMouseMove).toHaveBeenCalled();
 
       dispose();
     }));


### PR DESCRIPTION
Fixes #69 

`createFocusable`, `createButton` and `createToggleButton` should pass user props back with the returned props object.
I'm guessing that this is the way all of the primitives should work, but if not, let me know.

TODO:
- [x] fix createRadio tests
- [ ] fix createSwitch