### PR TITLE
Draft: feat(tooltip): create Tooltip

### DIFF
--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,0 +1,111 @@
+# @solid-aria/button
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [e6bac81]
+  - @solid-aria/utils@0.2.0
+  - @solid-aria/focus@0.1.4
+  - @solid-aria/interactions@0.1.4
+  - @solid-aria/toggle@0.1.3
+
+## 0.1.2
+
+### Patch Changes
+
+- Try manual release
+- Updated dependencies
+  - @solid-aria/focus@0.1.2
+  - @solid-aria/interactions@0.1.2
+  - @solid-aria/toggle@0.1.2
+  - @solid-aria/types@0.1.2
+  - @solid-aria/utils@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- 2ca4cfc: Change dependency versions of packages from "workspace^" to "^0.1.0" (current version) — Fixes #29
+  Move solid-primitives packages from peerDependencies to dependencies.
+- Updated dependencies [2ca4cfc]
+  - @solid-aria/focus@0.1.1
+  - @solid-aria/interactions@0.1.1
+  - @solid-aria/toggle@0.1.1
+  - @solid-aria/types@0.1.1
+  - @solid-aria/utils@0.1.1
+
+## 0.1.0
+
+### Minor Changes
+
+- dcfaa90: Release menu package, breaking change all primitives return plain object props instead of memoized value
+
+### Patch Changes
+
+- Updated dependencies [dcfaa90]
+  - @solid-aria/focus@0.1.0
+  - @solid-aria/interactions@0.1.0
+  - @solid-aria/toggle@0.1.0
+  - @solid-aria/types@0.1.0
+  - @solid-aria/utils@0.1.0
+
+## 0.0.6
+
+### Patch Changes
+
+- 84e543b: Bump solid-js peer dep to ^1.4.3
+- Updated dependencies [84e543b]
+  - @solid-aria/focus@0.0.9
+  - @solid-aria/interactions@0.0.7
+  - @solid-aria/toggle@0.0.10
+  - @solid-aria/types@0.0.5
+  - @solid-aria/utils@0.0.6
+
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [af59eb8]
+  - @solid-aria/interactions@0.0.6
+  - @solid-aria/focus@0.0.8
+  - @solid-aria/toggle@0.0.9
+
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [e2c1d42]
+  - @solid-aria/focus@0.0.7
+  - @solid-aria/toggle@0.0.8
+
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [20da459]
+  - @solid-aria/focus@0.0.6
+  - @solid-aria/toggle@0.0.7
+
+## 0.0.2
+
+### Patch Changes
+
+- 7eebd05: Add FocusScope, Dialog and Overlays related primitives
+- Updated dependencies [7eebd05]
+  - @solid-aria/focus@0.0.5
+  - @solid-aria/interactions@0.0.5
+  - @solid-aria/toggle@0.0.6
+  - @solid-aria/types@0.0.4
+  - @solid-aria/utils@0.0.5
+
+## 0.0.1
+
+### Patch Changes
+
+- e8be0a0: Release button package
+- Updated dependencies [e8be0a0]
+  - @solid-aria/interactions@0.0.4
+  - @solid-aria/toggle@0.0.5
+  - @solid-aria/utils@0.0.4
+  - @solid-aria/focus@0.0.4

--- a/packages/tooltip/LICENSE.md
+++ b/packages/tooltip/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Solid Aria Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -1,0 +1,163 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Aria&background=tiles&project=Button" alt="Solid Aria - Button">
+</p>
+
+# @solid-aria/button
+
+[![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-cc00ff.svg?style=for-the-badge&logo=pnpm)](https://pnpm.io/)
+[![turborepo](https://img.shields.io/badge/built%20with-turborepo-cc00ff.svg?style=for-the-badge&logo=turborepo)](https://turborepo.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-aria/button?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-aria/button)
+[![version](https://img.shields.io/npm/v/@solid-aria/button?style=for-the-badge)](https://www.npmjs.com/package/@solid-aria/button)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-aria#contribution-process)
+
+Buttons allow users to perform an action or to navigate to another page. They have multiple styles for various needs, and are ideal for calling attention to where a user needs to do something in order to move forward in a flow.
+
+## Installation
+
+```bash
+npm install @solid-aria/tooltip
+# or
+yarn add @solid-aria/tooltip
+# or
+pnpm add @solid-aria/tooltyp
+```
+
+## `createTooltip`
+
+Provides the behavior and accessibility implementation for a tooltip component.
+
+### Features
+
+On the surface, building a custom styled button seems simple. However, there are many cross browser inconsistencies in interactions and accessibility features to consider. `createTooltip` handles all of these interactions for you, so you can focus on the styling.
+
+- Native HTML `<button>` support
+- `<a>` and custom element type support via ARIA
+- Mouse and touch event handling, and press state management
+- Keyboard focus management and cross browser normalization
+- Keyboard event support for `Space` and `Enter` keys
+
+### How to use it
+
+By default, `createTooltip` assumes that you are using it with a native `<button>` element.
+
+```tsx
+import { AriaButtonProps, createTooltip } from "@solid-aria/button";
+
+function Button(props: AriaButtonProps) {
+  let ref: HTMLButtonElement | undefined;
+
+  const { buttonProps } = createTooltip(props, () => ref);
+
+  return (
+    <button {...buttonProps} ref={ref}>
+      {props.children}
+    </button>
+  );
+}
+
+function App() {
+  return <Button onPress={() => alert("Button pressed!")}>Test</Button>;
+}
+```
+
+### Using a custom element type
+
+Sometimes you might need to use an element other than a native `<button>`. `createTooltip` supports this via the `elementType` prop. When used with an element other than a native button, `createTooltip` automatically applies the necessary ARIA roles and attributes to ensure that the element is exposed to assistive technology as a button.
+
+In addition, this example shows usage of the `isPressed` value returned by `createTooltip` to properly style the button's active state. You could use the CSS `:active` pseudo class for this, but `isPressed` properly handles when the user drags their pointer off of the button, along with keyboard support and better touch screen support.
+
+```tsx
+import { AriaButtonProps, createTooltip } from "@solid-aria/button";
+import { mergeProps } from "solid-js";
+
+function Button(props: AriaButtonProps<"span">) {
+  let ref: HTMLButtonElement | undefined;
+
+  const createTooltipProps = mergeProps({ elementType: "span" }, props);
+
+  const { buttonProps, isPressed } = createTooltip(createTooltipProps, () => ref);
+
+  return (
+    <span
+      {...buttonProps}
+      style={{
+        background: isPressed() ? "darkgreen" : "green",
+        color: "white",
+        padding: "10px",
+        cursor: "pointer",
+        "user-select": "none",
+        "-webkit-user-select": "none"
+      }}
+      ref={ref}
+    >
+      {props.children}
+    </span>
+  );
+}
+
+function App() {
+  return <Button onPress={() => alert("Button pressed!")}>Test</Button>;
+}
+```
+
+## `createToggleButton`
+
+Provides the behavior and accessibility implementation for a toggle button component. ToggleButtons allow users to toggle a selection on or off, for example switching between two states or modes.
+
+### Features
+
+Toggle buttons are similar to action buttons, but support an additional selection state that is toggled when a user presses the button. There is no built-in HTML element that represents a toggle button, so Solid Aria implements it using ARIA attributes.
+
+- Native HTML `<button>`, `<a>`, and custom element type support
+- Exposed as a toggle button via ARIA
+- Mouse and touch event handling, and press state management
+- Keyboard focus management and cross browser normalization
+- Keyboard event support for `Space` and `Enter` keys
+
+### How to use it
+
+By default, `createToggleButton` assumes that you are using it with a native `<button>` element. You can use a custom element type by passing the `elementType` prop to `createToggleButton`. See the `createTooltip` docs for an example of this.
+
+The following example shows how to use the `createToggleButton` to build a toggle button. The toggle state is used to switch between a green and blue background when unselected and selected respectively. In addition, the `isPressed` state is used to adjust the background to be darker when the user presses down on the button.
+
+```tsx
+import { AriaToggleButtonProps, createToggleButton } from "@solid-aria/button";
+
+function ToggleButton(props: AriaToggleButtonProps) {
+  let ref: HTMLButtonElement | undefined;
+
+  const { buttonProps, isPressed, state } = createToggleButton(props, () => ref);
+
+  return (
+    <button
+      {...buttonProps}
+      style={{
+        background: isPressed()
+          ? state.isSelected()
+            ? "darkblue"
+            : "darkgreen"
+          : state.isSelected()
+          ? "blue"
+          : "green",
+        color: "white",
+        padding: "10px",
+        cursor: "pointer",
+        "user-select": "none",
+        "-webkit-user-select": "none",
+        border: "none"
+      }}
+      ref={ref}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+function App() {
+  return <ToggleButton>Test</ToggleButton>;
+}
+```
+
+## Changelog
+
+All notable changes are described in the [CHANGELOG.md](./CHANGELOG.md) file.

--- a/packages/tooltip/dev/index.html
+++ b/packages/tooltip/dev/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Solid App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script src="./index.tsx" type="module"></script>
+  </body>
+</html>

--- a/packages/tooltip/dev/index.tsx
+++ b/packages/tooltip/dev/index.tsx
@@ -1,0 +1,7 @@
+import { render } from "solid-js/web";
+
+function App() {
+  return <div>Hello Solid Aria!</div>;
+}
+
+render(() => <App />, document.getElementById("root") as HTMLDivElement);

--- a/packages/tooltip/dev/vite.config.ts
+++ b/packages/tooltip/dev/vite.config.ts
@@ -1,0 +1,3 @@
+import { viteConfig } from "../../../configs/vite.config";
+
+export default viteConfig;

--- a/packages/tooltip/jest.config.cjs
+++ b/packages/tooltip/jest.config.cjs
@@ -1,0 +1,5 @@
+const baseJest = require("../../configs/jest.config.cjs");
+
+module.exports = {
+  ...baseJest
+};

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@solid-aria/tooltip",
+  "version": "0.0.1",
+  "private": false,
+  "description": "Primitives for building accessible tooltip component.",
+  "keywords": [
+    "solid",
+    "aria",
+    "headless",
+    "design",
+    "system",
+    "components"
+  ],
+  "homepage": "https://github.com/solidjs-community/solid-aria/tree/main/packages/tooltip#readme",
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-aria/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-aria.git"
+  },
+  "license": "MIT",
+  "author": "Helio Alves <heliosjfa.dev@gmail.com>",
+  "contributors": [],
+  "sideEffects": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "dev": "vite serve dev --host",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@solid-aria/focus": "^0.1.4",
+    "@solid-aria/interactions": "^0.1.4",
+    "@solid-aria/overlays": "^0.1.3",
+    "@solid-aria/types": "^0.1.2",
+    "@solid-aria/utils": "^0.2.0"
+  },
+  "devDependencies": {
+    "solid-js": "^1.4.4"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.4.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "primitive": {
+    "name": "tooltip",
+    "stage": 0,
+    "list": [],
+    "category": ""
+  }
+}

--- a/packages/tooltip/src/createTooltip.ts
+++ b/packages/tooltip/src/createTooltip.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Solid Aria Working Group.
+ * MIT License
+ *
+ * Portions of this file are based on code from react-spectrum.
+ * Copyright 2020 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createHover } from "@solid-aria/interactions/src";
+import { filterDOMProps } from "@solid-aria/utils/src";
+import { Accessor, JSX, mergeProps } from "solid-js";
+
+import { CreateTooltipTriggerState } from "./createTooltipTriggerState";
+import { AriaTooltipProps } from "./types";
+
+export interface TooltipAria {
+  /**
+   * Props for the tooltip element.
+   */
+  tooltipProps: JSX.HTMLAttributes<any>;
+}
+
+/**
+ * Provides the accessibility implementation for a Tooltip component.
+ */
+export function createTooltip(
+  props: AriaTooltipProps,
+  ref: Accessor<any>,
+  state?: CreateTooltipTriggerState
+): TooltipAria {
+  const domProps = filterDOMProps(props, { labelable: true });
+  const { hoverProps } = createHover({
+    onHoverStart: () => state?.open(true),
+    onHoverEnd: () => state?.close()
+  });
+
+  const tooltipProps: JSX.HTMLAttributes<any> = mergeProps(domProps, hoverProps, {
+    role: "tooltip" as TooltipAria["tooltipProps"]["role"] // Typescript throws an error because role is a string
+  });
+
+  return { tooltipProps };
+}

--- a/packages/tooltip/src/createTooltipTrigger.ts
+++ b/packages/tooltip/src/createTooltipTrigger.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 Solid Aria Working Group.
+ * MIT License
+ *
+ * Portions of this file are based on code from react-spectrum.
+ * Copyright 2020 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createFocusable } from "@solid-aria/focus/src";
+import {
+  createHover,
+  CreateHoverProps,
+  createInteractionModality,
+  createPress,
+  CreatePressProps,
+  isKeyboardFocusVisible
+} from "@solid-aria/interactions/src";
+import { FocusEvents } from "@solid-aria/types/src";
+import { createId } from "@solid-aria/utils/src";
+import { Accessor, createEffect, JSX, mergeProps } from "solid-js";
+
+import { CreateTooltipTriggerState } from "./createTooltipTriggerState";
+import { TooltipTriggerProps } from "./types";
+
+export interface TooltipTriggerAria {
+  /**
+   * Props for the trigger element.
+   */
+  triggerProps: JSX.HTMLAttributes<any> & CreatePressProps & CreateHoverProps & FocusEvents;
+
+  /**
+   * Props for the overlay container element.
+   */
+  tooltipProps: JSX.HTMLAttributes<any>;
+}
+
+/**
+ * Provides the accessibility implementation for a Tooltip component.
+ * @param props - Props to be applied to the tooltip.
+ * @param ref - A ref to a DOM element for the tooltip.
+ * @param state
+ */
+export function createTooltipTrigger(
+  props: TooltipTriggerProps,
+  ref: Accessor<any>,
+  state: CreateTooltipTriggerState
+): TooltipTriggerAria {
+  const modality = createInteractionModality();
+  const tooltipId = createId();
+  let isHovered = false;
+  let isFocused = false;
+
+  const handleShow = () => {
+    if (isHovered || isFocused) {
+      state.open(isFocused);
+    }
+  };
+
+  const handleHide = (immediate?: boolean) => {
+    if (!isHovered && !isFocused) {
+      state.close(immediate);
+    }
+  };
+
+  createEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Escape after clicking something can give it keyboard focus
+      // dismiss tooltip on esc key press
+      if (e.key === "Escape") {
+        state.close(true);
+      }
+    };
+
+    if (state.isOpen()) {
+      document.addEventListener("keydown", onKeyDown, true);
+      return () => {
+        document.removeEventListener("keydown", onKeyDown, true);
+      };
+    }
+  });
+
+  const onHoverStart = () => {
+    if (props.trigger === "focus") {
+      return;
+    }
+    // In chrome, if you hover a trigger, then another element obscures it, due to keyboard
+    // interactions for example, hover will end. When hover is restored after that element disappears,
+    // focus moves on for example, then the tooltip will reopen. We check the modality to know if the hover
+    // is the result of moving the mouse.
+    isHovered = modality() === "pointer";
+    handleShow();
+  };
+  const onHoverEnd = () => {
+    if (props.trigger === "focus") {
+      return;
+    }
+    // no matter how the trigger is left, we should close the tooltip
+    isFocused = false;
+    isHovered = false;
+    handleHide();
+  };
+
+  const onPressStart = () => {
+    // no matter how the trigger is pressed, we should close the tooltip
+    isFocused = false;
+    isHovered = false;
+    handleHide(true);
+  };
+
+  // TODO
+  // The type onFocus requires an event of type FocusEvent to be passed but in
+  // react-aria they are not passing it.
+
+  const onFocus = (e: FocusEvent) => {
+    const isVisible = isKeyboardFocusVisible();
+    if (isVisible) {
+      isFocused = true;
+      handleShow();
+    }
+  };
+
+  const onBlur = () => {
+    isFocused = false;
+    isHovered = false;
+    handleHide(true);
+  };
+
+  const { hoverProps } = createHover({
+    isDisabled: props.isDisabled,
+    onHoverStart,
+    onHoverEnd
+  });
+
+  const { pressProps } = createPress({ onPressStart });
+
+  const { focusableProps } = createFocusable(
+    {
+      isDisabled: props.isDisabled,
+      onFocus,
+      onBlur
+    },
+    ref
+  );
+
+  const mergedProps = mergeProps(focusableProps, hoverProps, pressProps);
+
+  return {
+    triggerProps: {
+      "aria-describedby": state.isOpen() ? tooltipId : undefined,
+      ...mergedProps
+    },
+    tooltipProps: {
+      id: tooltipId
+    }
+  };
+}

--- a/packages/tooltip/src/createTooltipTriggerState.ts
+++ b/packages/tooltip/src/createTooltipTriggerState.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Solid Aria Working Group.
+ * MIT License
+ *
+ * Portions of this file are based on code from react-spectrum.
+ * Copyright 2020 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createOverlayTriggerState } from "@solid-aria/overlays/src";
+import { Accessor, createEffect } from "solid-js";
+import { clearTimeout } from "timers";
+
+import { TooltipTriggerProps } from "./types";
+
+const TOOLTIP_DELAY = 1500; // this seems to be a 1.5 second delay, check with design
+const TOOLTIP_COOLDOWN = 500;
+
+export interface CreateTooltipTriggerState {
+  /** Whether the tooltip is currently showing. */
+  isOpen: Accessor<boolean>;
+  /**
+   * Shows the tooltip. By default, the tooltip becomes visible after a delay
+   * depending on a global warmup timer. The `immediate` option shows the
+   * tooltip immediately instead.
+   */
+  open(immediate?: boolean): void;
+  /** Hides the tooltip. */
+  close(immediate?: boolean): void;
+}
+
+type Timeout = ReturnType<typeof setTimeout>;
+
+const tooltips: Record<string, any> = {};
+let tooltipId = 0;
+let globalWarmedUp = false;
+let globalWarmUpTimeout: Timeout | null = null;
+let globalCooldownTimeout: Timeout | null = null;
+
+/**
+ * Manages state for a tooltip trigger. Tracks whether the tooltip is open, and provides
+ * methods to toggle this state. Ensures only one tooltip is open at a time and controls
+ * the delay for showing a tooltip.
+ */
+export function createTooltipTriggerState(
+  props: TooltipTriggerProps = {}
+): CreateTooltipTriggerState {
+  const { delay = TOOLTIP_DELAY } = props;
+  const { isOpen, open, close } = createOverlayTriggerState(props);
+  const id = () => `${++tooltipId}`;
+  let closeTimeout: Timeout | null;
+
+  const hideTooltip = (immediate?: boolean) => {
+    if (immediate) {
+      clearTimeout(closeTimeout as Timeout);
+      closeTimeout = null;
+      close();
+    } else if (!closeTimeout) {
+      closeTimeout = setTimeout(() => {
+        closeTimeout = null;
+        close();
+      }, TOOLTIP_COOLDOWN);
+    }
+
+    if (globalWarmUpTimeout) {
+      clearTimeout(globalWarmUpTimeout);
+      globalWarmUpTimeout = null;
+    }
+    if (globalWarmedUp) {
+      if (globalCooldownTimeout) {
+        clearTimeout(globalCooldownTimeout);
+      }
+      globalCooldownTimeout = setTimeout(() => {
+        delete tooltips[id()];
+        globalCooldownTimeout = null;
+        globalWarmedUp = false;
+      }, TOOLTIP_COOLDOWN);
+    }
+  };
+
+  const ensureTooltipEntry = () => {
+    tooltips[id()] = hideTooltip;
+  };
+
+  const closeOpenTooltips = () => {
+    for (const hideTooltipId in tooltips) {
+      if (hideTooltipId !== id()) {
+        tooltips[hideTooltipId](true);
+        delete tooltips[hideTooltipId];
+      }
+    }
+  };
+
+  const showTooltip = () => {
+    clearTimeout(closeTimeout as Timeout);
+    closeTimeout = null;
+    closeOpenTooltips();
+    ensureTooltipEntry();
+    globalWarmedUp = true;
+    open();
+    if (globalWarmUpTimeout) {
+      clearTimeout(globalWarmUpTimeout);
+      globalWarmUpTimeout = null;
+    }
+    if (globalCooldownTimeout) {
+      clearTimeout(globalCooldownTimeout);
+      globalCooldownTimeout = null;
+    }
+  };
+
+  const warmupTooltip = () => {
+    closeOpenTooltips();
+    ensureTooltipEntry();
+    if (!isOpen() && !globalWarmUpTimeout && !globalWarmedUp) {
+      globalWarmUpTimeout = setTimeout(() => {
+        globalWarmUpTimeout = null;
+        globalWarmedUp = true;
+        showTooltip();
+      }, delay);
+    } else if (!isOpen()) {
+      showTooltip();
+    }
+  };
+
+  createEffect(() => {
+    return () => {
+      clearTimeout(closeTimeout as Timeout);
+      const tooltip = tooltips[id()];
+      if (tooltip) {
+        delete tooltips[id()];
+      }
+    };
+  });
+
+  return {
+    isOpen,
+    open: immediate => {
+      if (!immediate && delay > 0 && !closeTimeout) {
+        warmupTooltip();
+      } else {
+        showTooltip();
+      }
+    },
+    close: hideTooltip
+  };
+}

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Solid Aria Working Group.
+ * MIT License
+ *
+ * Portions of this file are based on code from react-spectrum.
+ * Copyright 2020 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export { createTooltip } from "./createTooltip";
+export { createTooltipTrigger } from "./createTooltipTrigger";
+export { createTooltipTriggerState } from "./createTooltipTriggerState";
+export type { AriaTooltipProps, TooltipProps, TooltipTriggerProps } from "./types";

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Solid Aria Working Group.
+ * MIT License
+ *
+ * Portions of this file are based on code from react-spectrum.
+ * Copyright 2020 Adobe. All rights reserved.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { CreateOverlayTriggerStateProps } from "@solid-aria/overlays/src";
+import { AriaLabelingProps, DOMProps } from "@solid-aria/types/src";
+
+export interface TooltipProps {
+  isOpen?: boolean;
+}
+
+export interface AriaTooltipProps extends TooltipProps, DOMProps, AriaLabelingProps {}
+
+export interface TooltipTriggerProps extends CreateOverlayTriggerStateProps {
+  /**
+   * Whether the tooltip should be disabled, independent from the trigger.
+   */
+  isDisabled?: boolean;
+
+  /**
+   * The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
+   * @default 1500
+   */
+  delay?: number;
+
+  /**
+   * By default, opens for both focus and hover. Can be made to open only for focus.
+   */
+  trigger?: "focus";
+}

--- a/packages/tooltip/tsconfig.json
+++ b/packages/tooltip/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src", "./test", "./dev"],
+  "exclude": ["node_modules", "./dist"]
+}

--- a/packages/tooltip/tsup.config.ts
+++ b/packages/tooltip/tsup.config.ts
@@ -1,0 +1,3 @@
+import defaultConfig from "../../configs/tsup.config";
+
+export default defaultConfig;

--- a/packages/tooltip/vite.config.ts
+++ b/packages/tooltip/vite.config.ts
@@ -1,0 +1,3 @@
+import { viteConfig } from "../../configs/vite.config";
+
+export default viteConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,23 @@ importers:
     devDependencies:
       solid-js: 1.4.6
 
+  packages/tooltip:
+    specifiers:
+      '@solid-aria/focus': ^0.1.4
+      '@solid-aria/interactions': ^0.1.4
+      '@solid-aria/overlays': ^0.1.3
+      '@solid-aria/types': ^0.1.2
+      '@solid-aria/utils': ^0.2.0
+      solid-js: ^1.4.4
+    dependencies:
+      '@solid-aria/focus': link:../focus
+      '@solid-aria/interactions': link:../interactions
+      '@solid-aria/overlays': link:../overlays
+      '@solid-aria/types': link:../types
+      '@solid-aria/utils': link:../utils
+    devDependencies:
+      solid-js: 1.4.6
+
   packages/tree:
     specifiers:
       '@solid-aria/collection': ^0.2.0
@@ -3965,8 +3982,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
**This PR is dependent of https://github.com/solidjs-community/solid-aria/pull/73 since it has changes to** `createFocusable`

This is the port of Tooltip.

TODO 
- [ ] Tooltip
- [ ] Tests
- [ ] Update doc

This is my first contribution to the project. I am looking for feedback.

I have pretty much followed what `@react-aria/tooltip` is doing.

I'm having a Typescript error with the return of `createTooltipTrigger`.
I'm getting this error:
```
Types of property 'onFocus' are incompatible. 
Type 'EventHandlerUnion<any, 
FocusEvent> 
| EventHandlerUnion<HTMLElement, FocusEvent>
| undefined' is not assignable to type '((e: FocusEvent) => void) | undefined'.
```

Looking at the signature of `onFocus` from `FocusEvents` => `onFocus?: (e: FocusEvent) => void;` in `@solid-aria/types`, this is exactly the same signature as we have in `@react-aria/types`. In their implementation of `onFocus`, they are not passing the event to `onFocus` and it is not complaining in `@react-aria`

Looking at `createFocusable` interface `FocusableResult`, `focusableProps: JSX.HTMLAttributes<any>;` and `onFocus` in `HTMLAttributes` is indeed `onFocus?: EventHandlerUnion<T, FocusEvent>;`

@fabien-ml I see you worked in `createFocusable`, do you think you could help me out?
