### PR TITLE
fix(types): adds `exports.types` where applicable

### DIFF
--- a/.changeset/nine-cougars-sip.md
+++ b/.changeset/nine-cougars-sip.md
@@ -1,0 +1,9 @@
+---
+"@solid-aria/collection": patch
+"@solid-aria/focus": patch
+"@solid-aria/overlays": patch
+"@solid-aria/primitives": patch
+"@solid-aria/select": patch
+---
+
+fix(types): add `exports.types` to package.json

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -30,7 +30,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -30,7 +30,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -30,7 +30,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -30,7 +30,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -30,7 +30,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This allows editors that use `exports` in package.json to find the types.
This has been applied to all package.json's that contain `exports` field.

- Fixes #81 
- Couldn't test locally due to #82 